### PR TITLE
feat: added get_ticket_conversation functionality 

### DIFF
--- a/src/freshdesk_mcp/server.py
+++ b/src/freshdesk_mcp/server.py
@@ -297,6 +297,17 @@ async def search_tickets(query: str) -> Dict[str, Any]:
         response = await client.get(url, headers=headers, params=params)
         return response.json()
 
+@mcp.tool()
+async def get_ticket_conversation(ticket_id: int)-> list[Dict[str, Any]]:
+    """Get a ticket conversation in Freshdesk."""
+    url = f"https://{FRESHDESK_DOMAIN}.freshdesk.com/api/v2/tickets/{ticket_id}/conversations"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url, headers=headers)
+        return response.json()
+
 def main():
     logging.info("Starting Freshdesk MCP server")
     mcp.run(transport='stdio')

--- a/tests/test-fd-mcp.py
+++ b/tests/test-fd-mcp.py
@@ -1,5 +1,5 @@
 import asyncio
-from freshdesk_mcp.server import get_ticket, update_ticket
+from freshdesk_mcp.server import get_ticket, update_ticket, get_ticket_conversation
 
 async def test_get_ticket():
     ticket_id = "1289" #Replace with a test ticket Id
@@ -13,6 +13,12 @@ async def test_update_ticket():
     result = await update_ticket(ticket_id, ticket_fields)
     print(result)
 
+async def test_get_ticket_conversation():
+    ticket_id = 1294 #Replace with a test ticket Id 
+    result = await get_ticket_conversation(ticket_id)
+    print(result)
+
 if __name__ == "__main__":
     asyncio.run(test_get_ticket())
     asyncio.run(test_update_ticket())
+    asyncio.run(test_get_ticket_conversation())


### PR DESCRIPTION
### ✨ Feature: Add [`get_ticket_conversations`](https://github.com/effytech/freshdesk_mcp/issues/4) method to MCP Tools

---

### 📋 Description

- Introduced a new utility method: `get_ticket_conversations(ticket_id)`
  - Accepts a **ticket ID** as input
  - Returns the **list of conversations** associated with the ticket
  - Designed to follow existing structure and conventions in MCP Tools

---

### ✅ Testing

- Verified functionality using:
  - ✅ **MCP Inspector**
  - ✅ **Claude Desktop**
- Everything works as expected, with no regressions observed.

---

### 💡 Why This Matters

- Simplifies interaction with ticket data
- Reduces repetitive logic for fetching ticket conversations
- Enhances developer productivity when working with MCP Tools

---
