### PR TITLE
feat: Add get_agents function to retrieve Freshdesk agents

### DIFF
--- a/src/freshdesk_mcp/server.py
+++ b/src/freshdesk_mcp/server.py
@@ -353,6 +353,27 @@ async def update_ticket_conversation(conversation_id: int,body: str)-> Dict[str,
             return response.json()
         else:
             return f"Cannot update conversation ${response.json()}"
+        
+@mcp.tool()
+async def get_agents(page: Optional[int] = 1, per_page: Optional[int] = 30)-> list[Dict[str, Any]]:
+    """Get all agents in Freshdesk with pagination support."""
+    # Validate input parameters
+    if page < 1:
+        return {"error": "Page number must be greater than 0"}
+    
+    if per_page < 1 or per_page > 100:
+        return {"error": "Page size must be between 1 and 100"}
+    url = f"https://{FRESHDESK_DOMAIN}.freshdesk.com/api/v2/agents"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    params = {
+        "page": page,
+        "per_page": per_page
+    }
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url, headers=headers, params=params)
+        return response.json() 
 def main():
     logging.info("Starting Freshdesk MCP server")
     mcp.run(transport='stdio')

--- a/tests/test-fd-mcp.py
+++ b/tests/test-fd-mcp.py
@@ -1,5 +1,5 @@
 import asyncio
-from freshdesk_mcp.server import get_ticket, update_ticket, get_ticket_conversation, update_ticket_conversation
+from freshdesk_mcp.server import get_ticket, update_ticket, get_ticket_conversation, update_ticket_conversation,get_agents
 
 async def test_get_ticket():
     ticket_id = "1289" #Replace with a test ticket Id
@@ -24,9 +24,17 @@ async def test_update_ticket_conversation():
     result = await update_ticket_conversation(conversation_id, body)
     print(result)
 
+async def test_get_agents():
+    page = 1
+    per_page = 30
+    result = await get_agents(page, per_page)
+    print(result)
+
+
 
 if __name__ == "__main__":
     asyncio.run(test_get_ticket())
     asyncio.run(test_update_ticket())
     asyncio.run(test_get_ticket_conversation())
     asyncio.run(test_update_ticket_conversation())
+    asyncio.run(test_get_agents())


### PR DESCRIPTION
### ✨ Feature: Add `get_agents` Function to Retrieve Freshdesk Agents

---

### 📋 Description

- Added a new MCP Tool method: `get_agents()`
  - Retrieves all agents from the Freshdesk system
  - Includes **pagination support** to handle large agent lists efficiently
  - Returns agent metadata such as ID, name, email, role, and more

---

### ✅ Testing

- Successfully tested using:
  - ✅ **MCP Inspector**
  - ✅ **Claude Desktop**
- All results returned as expected
- No regressions or breaking changes observed

---

### 💡 Benefits

- Provides an easy way to fetch all Freshdesk agents
- Supports use cases like reporting, auditing, and ticket routing
- Complements other agent management tools (`view_agent`, `search_agents`, etc.)

---

Let me know if you'd like to include example output or API details!
