### PR TITLE
✨ Feature: Implement Group Management Tools – Create, List, and Update Groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "freshdesk-mcp"
-version = "0.2.3"
+version = "0.3.0"
 description = "An MCP server for Freshdesk"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "build>=1.2.2.post1",
     "httpx==0.28.1",
     "mcp[cli]>=1.3.0",
+    "pydantic>=2.10.6",
 ]
 
 [[project.authors]]

--- a/src/freshdesk_mcp/server.py
+++ b/src/freshdesk_mcp/server.py
@@ -684,6 +684,10 @@ async def update_group(group_id: int, group_fields: Dict[str, Any]) -> Dict[str,
     except Exception as e:
         return {"error": f"Validation error: {str(e)}"}
     url = f"https://{FRESHDESK_DOMAIN}/api/v2/groups/{group_id}"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    async with httpx.AsyncClient() as client:
         try:
             response = await client.put(url, headers=headers, json=group_data)
             response.raise_for_status()

--- a/tests/test-fd-mcp.py
+++ b/tests/test-fd-mcp.py
@@ -1,5 +1,5 @@
 import asyncio
-from freshdesk_mcp.server import get_ticket, update_ticket, get_ticket_conversation, update_ticket_conversation,get_agents, list_canned_responses, list_solution_articles, list_solution_categories,list_solution_folders
+from freshdesk_mcp.server import get_ticket, update_ticket, get_ticket_conversation, update_ticket_conversation,get_agents, list_canned_responses, list_solution_articles, list_solution_categories,list_solution_folders,list_groups,create_group
 
 async def test_get_ticket():
     ticket_id = "1289" #Replace with a test ticket Id
@@ -52,6 +52,15 @@ async def test_list_solution_articles():
     result = await list_solution_articles(folder_id)
     print(result)
 
+async def test_list_groups():
+    result = await list_groups()
+    print(result)
+async def test_create_group():
+    group_fields = {
+       
+    }
+    result = await create_group(group_fields)
+    print(result)
 if __name__ == "__main__":
     # asyncio.run(test_get_ticket())
     # asyncio.run(test_update_ticket())
@@ -61,4 +70,6 @@ if __name__ == "__main__":
     # asyncio.run(test_list_canned_responses())
     # asyncio.run(test_list_solution_articles())
     # asyncio.run(test_list_solution_folders())
-    asyncio.run(test_list_solution_categories())
+    # asyncio.run(test_list_solution_categories())
+    # asyncio.run(test_list_groups())
+    asyncio.run(test_create_group())

--- a/uv.lock
+++ b/uv.lock
@@ -83,12 +83,13 @@ wheels = [
 
 [[package]]
 name = "freshdesk-mcp"
-version = "0.1.0"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "build" },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
+    { name = "pydantic" },
 ]
 
 [package.metadata]
@@ -96,6 +97,7 @@ requires-dist = [
     { name = "build", specifier = ">=1.2.2.post1" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.3.0" },
+    { name = "pydantic", specifier = ">=2.10.6" },
 ]
 
 [[package]]


### PR DESCRIPTION
### ✨ Feature: Implement Group Management Tools – Create, List, and Update Groups  

---

### 📋 Description  

Implemented the following **group management tools** for Freshdesk using MCP:  

- `create_group(group_data)` – Creates a new group with the provided data.  
- `list_groups()` – Lists all available groups.  
- `update_group(group_id, updates)` – Updates an existing group based on the provided group ID and update data.  

Additionally, **schema validation** has been added using **Pydantic** to ensure the integrity and correctness of the data.

---

### ✅ Testing  

- Verified all functions using **MCP Inspector** and **Claude Client**.  
- Ensured proper schema validation with Pydantic for input data.  
- No regressions or breaking changes observed.  

---

### 💡 Impact  

- Provides structured group management via MCP Tools.  
- Reduces manual intervention in group creation and updates.  
- Improves data validation and reduces errors with Pydantic schema enforcement.  
