### PR TITLE
Version Update: Freshdesk MCP Server v1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "freshdesk-mcp"
-version = "1.0.0"
+version = "1.1.0"
 description = "An MCP server for Freshdesk"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This update bumps the version of the Freshdesk MCP server from v1.0.0 to v1.1.0, reflecting enhancements to support Fresdhesk companies API. The project remains compatible with Python 3.10 and above