### PR TITLE
Add missing CRUD tools

### DIFF
--- a/src/freshdesk_mcp/server.py
+++ b/src/freshdesk_mcp/server.py
@@ -509,6 +509,26 @@ async def search_contacts(query: str)-> list[Dict[str, Any]]:
         return response.json()
 
 @mcp.tool()
+async def create_contact(contact_fields: Dict[str, Any]) -> Dict[str, Any]:
+    """Create a contact in Freshdesk. Requires at least one of: email, phone, mobile, or twitter_id."""
+    if not any(contact_fields.get(k) for k in ("email", "phone", "mobile", "twitter_id")):
+        return {"error": "At least one of 'email', 'phone', 'mobile', or 'twitter_id' must be provided."}
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/contacts"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}",
+        "Content-Type": "application/json"
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(url, headers=headers, json=contact_fields)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to create contact: {str(e)}", "details": e.response.json() if e.response else None}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
+
+@mcp.tool()
 async def update_contact(contact_id: int, contact_fields: Dict[str, Any])-> Dict[str, Any]:
     """Update a contact in Freshdesk."""
     url = f"https://{FRESHDESK_DOMAIN}/api/v2/contacts/{contact_id}"
@@ -521,6 +541,26 @@ async def update_contact(contact_id: int, contact_fields: Dict[str, Any])-> Dict
     async with httpx.AsyncClient() as client:
         response = await client.put(url, headers=headers, json=data)
         return response.json()
+
+@mcp.tool()
+async def delete_contact(contact_id: int) -> Dict[str, Any]:
+    """Delete a contact in Freshdesk."""
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/contacts/{contact_id}"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.delete(url, headers=headers)
+            if response.status_code == 204:
+                return {"success": True, "message": "Contact deleted successfully"}
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to delete contact: {str(e)}"}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
+
 @mcp.tool()
 async def list_canned_responses(folder_id: int)-> list[Dict[str, Any]]:
     """List all canned responses in Freshdesk."""
@@ -585,6 +625,26 @@ async def update_canned_response(canned_response_id: int, canned_response_fields
     async with httpx.AsyncClient() as client:
         response = await client.put(url, headers=headers, json=canned_response_fields)
         return response.json()
+
+@mcp.tool()
+async def delete_canned_response(canned_response_id: int) -> Dict[str, Any]:
+    """Delete a canned response in Freshdesk."""
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/canned_responses/{canned_response_id}"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.delete(url, headers=headers)
+            if response.status_code == 204:
+                return {"success": True, "message": "Canned response deleted successfully"}
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to delete canned response: {str(e)}"}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
+
 @mcp.tool()
 async def create_canned_response_folder(name: str)-> Dict[str, Any]:
     """Create a canned response folder in Freshdesk."""
@@ -612,6 +672,25 @@ async def update_canned_response_folder(folder_id: int, name: str)-> Dict[str, A
     async with httpx.AsyncClient() as client:
         response = await client.put(url, headers=headers, json=data)
         return response.json()
+
+@mcp.tool()
+async def delete_canned_response_folder(folder_id: int) -> Dict[str, Any]:
+    """Delete a canned response folder in Freshdesk."""
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/canned_response_folders/{folder_id}"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.delete(url, headers=headers)
+            if response.status_code == 204:
+                return {"success": True, "message": "Canned response folder deleted successfully"}
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to delete canned response folder: {str(e)}"}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
 
 @mcp.tool()
 async def list_solution_articles(folder_id: int)-> list[Dict[str, Any]]:
@@ -920,6 +999,26 @@ async def search_agents(query: str) -> list[Dict[str, Any]]:
     async with httpx.AsyncClient() as client:
         response = await client.get(url, headers=headers)
         return response.json()
+
+@mcp.tool()
+async def delete_agent(agent_id: int) -> Dict[str, Any]:
+    """Delete an agent in Freshdesk."""
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/agents/{agent_id}"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.delete(url, headers=headers)
+            if response.status_code == 204:
+                return {"success": True, "message": "Agent deleted successfully"}
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to delete agent: {str(e)}"}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
+
 @mcp.tool()
 async def list_groups(page: Optional[int] = 1, per_page: Optional[int] = 30)-> list[Dict[str, Any]]:
     """List all groups in Freshdesk."""
@@ -1007,6 +1106,25 @@ async def update_ticket_field(ticket_field_id: int, ticket_field_fields: Dict[st
         return response.json()
 
 @mcp.tool()
+async def delete_ticket_field(ticket_field_id: int) -> Dict[str, Any]:
+    """Delete a ticket field in Freshdesk."""
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/admin/ticket_fields/{ticket_field_id}"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.delete(url, headers=headers)
+            if response.status_code == 204:
+                return {"success": True, "message": "Ticket field deleted successfully"}
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to delete ticket field: {str(e)}"}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
+
+@mcp.tool()
 async def update_group(group_id: int, group_fields: Dict[str, Any]) -> Dict[str, Any]:
     """Update a group in Freshdesk."""
     try:
@@ -1029,6 +1147,25 @@ async def update_group(group_id: int, group_fields: Dict[str, Any]) -> Dict[str,
                 "error": f"Failed to update group: {str(e)}",
                 "details": e.response.json() if e.response else None
             }
+
+@mcp.tool()
+async def delete_group(group_id: int) -> Dict[str, Any]:
+    """Delete a group in Freshdesk."""
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/groups/{group_id}"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.delete(url, headers=headers)
+            if response.status_code == 204:
+                return {"success": True, "message": "Group deleted successfully"}
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to delete group: {str(e)}"}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
 
 @mcp.tool()
 async def list_contact_fields()-> list[Dict[str, Any]]:
@@ -1080,6 +1217,26 @@ async def update_contact_field(contact_field_id: int, contact_field_fields: Dict
     async with httpx.AsyncClient() as client:
         response = await client.put(url, headers=headers, json=contact_field_fields)
         return response.json()
+
+@mcp.tool()
+async def delete_contact_field(contact_field_id: int) -> Dict[str, Any]:
+    """Delete a contact field in Freshdesk."""
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/contact_fields/{contact_field_id}"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.delete(url, headers=headers)
+            if response.status_code == 204:
+                return {"success": True, "message": "Contact field deleted successfully"}
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to delete contact field: {str(e)}"}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
+
 @mcp.tool()
 async def get_field_properties(field_name: str):
     """Get properties of a specific field by name."""
@@ -1274,6 +1431,63 @@ async def list_company_fields() -> List[Dict[str, Any]]:
             return response.json()
         except httpx.HTTPStatusError as e:
             return {"error": f"Failed to fetch company fields: {str(e)}"}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
+
+@mcp.tool()
+async def create_company(company_fields: Dict[str, Any]) -> Dict[str, Any]:
+    """Create a company in Freshdesk. Requires at least 'name'."""
+    if not company_fields.get("name"):
+        return {"error": "The 'name' field is required to create a company."}
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/companies"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}",
+        "Content-Type": "application/json"
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(url, headers=headers, json=company_fields)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to create company: {str(e)}", "details": e.response.json() if e.response else None}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
+
+@mcp.tool()
+async def update_company(company_id: int, company_fields: Dict[str, Any]) -> Dict[str, Any]:
+    """Update a company in Freshdesk."""
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/companies/{company_id}"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}",
+        "Content-Type": "application/json"
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.put(url, headers=headers, json=company_fields)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to update company: {str(e)}", "details": e.response.json() if e.response else None}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
+
+@mcp.tool()
+async def delete_company(company_id: int) -> Dict[str, Any]:
+    """Delete a company in Freshdesk."""
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/companies/{company_id}"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.delete(url, headers=headers)
+            if response.status_code == 204:
+                return {"success": True, "message": "Company deleted successfully"}
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to delete company: {str(e)}"}
         except Exception as e:
             return {"error": f"An unexpected error occurred: {str(e)}"}
 

--- a/src/freshdesk_mcp/server.py
+++ b/src/freshdesk_mcp/server.py
@@ -763,6 +763,103 @@ async def update_solution_article(article_id: int, article_fields: Dict[str, Any
         return response.json()
 
 @mcp.tool()
+async def delete_solution_article(article_id: int) -> Dict[str, Any]:
+    """Delete a solution article in Freshdesk."""
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/solutions/articles/{article_id}"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.delete(url, headers=headers)
+            if response.status_code == 204:
+                return {"success": True, "message": "Solution article deleted successfully"}
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to delete solution article: {str(e)}"}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
+
+@mcp.tool()
+async def delete_solution_folder(folder_id: int) -> Dict[str, Any]:
+    """Delete a solution folder in Freshdesk."""
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/solutions/folders/{folder_id}"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.delete(url, headers=headers)
+            if response.status_code == 204:
+                return {"success": True, "message": "Solution folder deleted successfully"}
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to delete solution folder: {str(e)}"}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
+
+@mcp.tool()
+async def delete_solution_category(category_id: int) -> Dict[str, Any]:
+    """Delete a solution category in Freshdesk."""
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/solutions/categories/{category_id}"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.delete(url, headers=headers)
+            if response.status_code == 204:
+                return {"success": True, "message": "Solution category deleted successfully"}
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to delete solution category: {str(e)}"}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
+
+@mcp.tool()
+async def search_solution_articles(term: str, page: int = 1, per_page: int = 30) -> Dict[str, Any]:
+    """Search for solution articles in the Freshdesk knowledge base."""
+    if page < 1:
+        return {"error": "Page number must be greater than 0"}
+    if per_page < 1 or per_page > 100:
+        return {"error": "Page size must be between 1 and 100"}
+
+    url = f"https://{FRESHDESK_DOMAIN}/api/v2/solutions/articles/search"
+    headers = {
+        "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
+    }
+    params = {
+        "term": term,
+        "page": page,
+        "per_page": per_page
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(url, headers=headers, params=params)
+            response.raise_for_status()
+
+            link_header = response.headers.get('Link', '')
+            pagination_info = parse_link_header(link_header)
+            articles = response.json()
+
+            return {
+                "articles": articles,
+                "pagination": {
+                    "current_page": page,
+                    "next_page": pagination_info.get("next"),
+                    "prev_page": pagination_info.get("prev"),
+                    "per_page": per_page
+                }
+            }
+        except httpx.HTTPStatusError as e:
+            return {"error": f"Failed to search solution articles: {str(e)}"}
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {str(e)}"}
+
+@mcp.tool()
 async def view_agent(agent_id: int)-> Dict[str, Any]:
     """View an agent in Freshdesk."""
     url = f"https://{FRESHDESK_DOMAIN}/api/v2/agents/{agent_id}"

--- a/tests/test-fd-mcp.py
+++ b/tests/test-fd-mcp.py
@@ -1,4 +1,12 @@
 import asyncio
+import os
+import sys
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
 from freshdesk_mcp.server import get_ticket, update_ticket, get_ticket_conversation, update_ticket_conversation, get_agents, list_canned_responses, list_solution_articles, list_solution_categories, list_solution_folders, list_groups, create_group, create_contact_field, create_canned_response_folder, update_canned_response_folder, create_canned_response, update_canned_response, view_canned_response, view_ticket_summary, update_ticket_summary, delete_ticket_summary, delete_solution_article, delete_solution_folder, delete_solution_category, search_solution_articles
 
 async def test_get_ticket():
@@ -138,16 +146,25 @@ async def test_view_canned_response():
     print(result)
 
 async def test_delete_solution_article():
+    if not os.getenv("RUN_DESTRUCTIVE_TESTS"):
+        print("Skipping test_delete_solution_article (set RUN_DESTRUCTIVE_TESTS=1 to run)")
+        return
     article_id = 1  # Replace with a test article Id
     result = await delete_solution_article(article_id)
     print(result)
 
 async def test_delete_solution_folder():
+    if not os.getenv("RUN_DESTRUCTIVE_TESTS"):
+        print("Skipping test_delete_solution_folder (set RUN_DESTRUCTIVE_TESTS=1 to run)")
+        return
     folder_id = 1  # Replace with a test folder Id
     result = await delete_solution_folder(folder_id)
     print(result)
 
 async def test_delete_solution_category():
+    if not os.getenv("RUN_DESTRUCTIVE_TESTS"):
+        print("Skipping test_delete_solution_category (set RUN_DESTRUCTIVE_TESTS=1 to run)")
+        return
     category_id = 1  # Replace with a test category Id
     result = await delete_solution_category(category_id)
     print(result)

--- a/tests/test-fd-mcp.py
+++ b/tests/test-fd-mcp.py
@@ -1,5 +1,5 @@
 import asyncio
-from freshdesk_mcp.server import get_ticket, update_ticket, get_ticket_conversation, update_ticket_conversation, get_agents, list_canned_responses, list_solution_articles, list_solution_categories, list_solution_folders, list_groups, create_group, create_contact_field, create_canned_response_folder, update_canned_response_folder, create_canned_response, update_canned_response, view_canned_response, view_ticket_summary, update_ticket_summary, delete_ticket_summary
+from freshdesk_mcp.server import get_ticket, update_ticket, get_ticket_conversation, update_ticket_conversation, get_agents, list_canned_responses, list_solution_articles, list_solution_categories, list_solution_folders, list_groups, create_group, create_contact_field, create_canned_response_folder, update_canned_response_folder, create_canned_response, update_canned_response, view_canned_response, view_ticket_summary, update_ticket_summary, delete_ticket_summary, delete_solution_article, delete_solution_folder, delete_solution_category, search_solution_articles
 
 async def test_get_ticket():
     ticket_id = "1289" #Replace with a test ticket Id
@@ -137,6 +137,25 @@ async def test_view_canned_response():
     result = await view_canned_response(canned_response_id)
     print(result)
 
+async def test_delete_solution_article():
+    article_id = 1  # Replace with a test article Id
+    result = await delete_solution_article(article_id)
+    print(result)
+
+async def test_delete_solution_folder():
+    folder_id = 1  # Replace with a test folder Id
+    result = await delete_solution_folder(folder_id)
+    print(result)
+
+async def test_delete_solution_category():
+    category_id = 1  # Replace with a test category Id
+    result = await delete_solution_category(category_id)
+    print(result)
+
+async def test_search_solution_articles():
+    result = await search_solution_articles(term="how to")
+    print(result)
+
 if __name__ == "__main__":
     # asyncio.run(test_get_ticket())
     # asyncio.run(test_update_ticket())
@@ -156,3 +175,7 @@ if __name__ == "__main__":
     # asyncio.run(test_create_canned_response())
     # asyncio.run(test_view_canned_response())
     # asyncio.run(test_update_canned_response())
+    # asyncio.run(test_delete_solution_article())
+    # asyncio.run(test_delete_solution_folder())
+    # asyncio.run(test_delete_solution_category())
+    # asyncio.run(test_search_solution_articles())

--- a/tests/test_solution_functions.py
+++ b/tests/test_solution_functions.py
@@ -1,0 +1,211 @@
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock
+import json
+import os
+import sys
+import asyncio
+
+# Add the parent directory to the path so we can import the module
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import src.freshdesk_mcp.server as server_module
+from src.freshdesk_mcp.server import (
+    delete_solution_article,
+    delete_solution_folder,
+    delete_solution_category,
+    search_solution_articles,
+)
+
+
+def _make_async_client_mock(mock_response):
+    """Return an AsyncClient context-manager mock that yields mock_response."""
+    mock_client = AsyncMock()
+    mock_client.delete = AsyncMock(return_value=mock_response)
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return mock_client
+
+
+class TestDeleteSolutionArticle(unittest.TestCase):
+    def setUp(self):
+        server_module.FRESHDESK_DOMAIN = "testdomain.freshdesk.com"
+        server_module.FRESHDESK_API_KEY = "test-api-key"
+
+    def test_delete_returns_success_on_204(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = _make_async_client_mock(mock_response)
+        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+            result = asyncio.run(delete_solution_article(42))
+
+        self.assertTrue(result.get("success"))
+        self.assertIn("message", result)
+
+    def test_delete_propagates_http_error(self):
+        import httpx
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "Not Found", request=MagicMock(), response=mock_response
+            )
+        )
+
+        mock_client = _make_async_client_mock(mock_response)
+        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+            result = asyncio.run(delete_solution_article(999))
+
+        self.assertIn("error", result)
+
+
+class TestDeleteSolutionFolder(unittest.TestCase):
+    def setUp(self):
+        server_module.FRESHDESK_DOMAIN = "testdomain.freshdesk.com"
+        server_module.FRESHDESK_API_KEY = "test-api-key"
+
+    def test_delete_returns_success_on_204(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = _make_async_client_mock(mock_response)
+        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+            result = asyncio.run(delete_solution_folder(10))
+
+        self.assertTrue(result.get("success"))
+        self.assertIn("message", result)
+
+    def test_delete_propagates_http_error(self):
+        import httpx
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "Forbidden", request=MagicMock(), response=mock_response
+            )
+        )
+
+        mock_client = _make_async_client_mock(mock_response)
+        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+            result = asyncio.run(delete_solution_folder(999))
+
+        self.assertIn("error", result)
+
+
+class TestDeleteSolutionCategory(unittest.TestCase):
+    def setUp(self):
+        server_module.FRESHDESK_DOMAIN = "testdomain.freshdesk.com"
+        server_module.FRESHDESK_API_KEY = "test-api-key"
+
+    def test_delete_returns_success_on_204(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = _make_async_client_mock(mock_response)
+        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+            result = asyncio.run(delete_solution_category(5))
+
+        self.assertTrue(result.get("success"))
+        self.assertIn("message", result)
+
+    def test_delete_propagates_http_error(self):
+        import httpx
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "Server Error", request=MagicMock(), response=mock_response
+            )
+        )
+
+        mock_client = _make_async_client_mock(mock_response)
+        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+            result = asyncio.run(delete_solution_category(999))
+
+        self.assertIn("error", result)
+
+
+class TestSearchSolutionArticles(unittest.TestCase):
+    def setUp(self):
+        server_module.FRESHDESK_DOMAIN = "testdomain.freshdesk.com"
+        server_module.FRESHDESK_API_KEY = "test-api-key"
+
+    def test_search_returns_articles_and_pagination_envelope(self):
+        sample_articles = [{"id": 1, "title": "How to reset password"}]
+        link_header = (
+            '<https://testdomain.freshdesk.com/api/v2/solutions/articles/search?page=2>; rel="next"'
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_response.headers = {"Link": link_header}
+        mock_response.json = MagicMock(return_value=sample_articles)
+
+        mock_client = _make_async_client_mock(mock_response)
+        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+            result = asyncio.run(search_solution_articles(term="reset password", page=1, per_page=10))
+
+        self.assertIn("articles", result)
+        self.assertIn("pagination", result)
+        self.assertEqual(result["articles"], sample_articles)
+        self.assertEqual(result["pagination"]["current_page"], 1)
+        self.assertEqual(result["pagination"]["next_page"], 2)
+        self.assertIsNone(result["pagination"]["prev_page"])
+        self.assertEqual(result["pagination"]["per_page"], 10)
+
+    def test_search_pagination_with_prev_and_next(self):
+        link_header = (
+            '<https://testdomain.freshdesk.com/api/v2/solutions/articles/search?page=3>; rel="next", '
+            '<https://testdomain.freshdesk.com/api/v2/solutions/articles/search?page=1>; rel="prev"'
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_response.headers = {"Link": link_header}
+        mock_response.json = MagicMock(return_value=[])
+
+        mock_client = _make_async_client_mock(mock_response)
+        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+            result = asyncio.run(search_solution_articles(term="test", page=2, per_page=30))
+
+        self.assertEqual(result["pagination"]["current_page"], 2)
+        self.assertEqual(result["pagination"]["next_page"], 3)
+        self.assertEqual(result["pagination"]["prev_page"], 1)
+
+    def test_search_validates_page_bounds(self):
+        result = asyncio.run(search_solution_articles(term="test", page=0))
+        self.assertIn("error", result)
+
+    def test_search_validates_per_page_bounds(self):
+        result = asyncio.run(search_solution_articles(term="test", per_page=101))
+        self.assertIn("error", result)
+
+    def test_search_propagates_http_error(self):
+        import httpx
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "Unauthorized", request=MagicMock(), response=mock_response
+            )
+        )
+        mock_response.headers = {}
+
+        mock_client = _make_async_client_mock(mock_response)
+        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+            result = asyncio.run(search_solution_articles(term="test"))
+
+        self.assertIn("error", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_solution_functions.py
+++ b/tests/test_solution_functions.py
@@ -1,14 +1,16 @@
 import unittest
 from unittest.mock import patch, MagicMock, AsyncMock
-import json
-import os
-import sys
 import asyncio
+import httpx
+import sys
+from pathlib import Path
 
-# Add the parent directory to the path so we can import the module
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-import src.freshdesk_mcp.server as server_module
-from src.freshdesk_mcp.server import (
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+import freshdesk_mcp.server as server_module
+from freshdesk_mcp.server import (
     delete_solution_article,
     delete_solution_folder,
     delete_solution_category,
@@ -37,14 +39,13 @@ class TestDeleteSolutionArticle(unittest.TestCase):
         mock_response.raise_for_status = MagicMock()
 
         mock_client = _make_async_client_mock(mock_response)
-        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+        with patch("freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
             result = asyncio.run(delete_solution_article(42))
 
         self.assertTrue(result.get("success"))
         self.assertIn("message", result)
 
     def test_delete_propagates_http_error(self):
-        import httpx
 
         mock_response = MagicMock()
         mock_response.status_code = 404
@@ -55,7 +56,7 @@ class TestDeleteSolutionArticle(unittest.TestCase):
         )
 
         mock_client = _make_async_client_mock(mock_response)
-        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+        with patch("freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
             result = asyncio.run(delete_solution_article(999))
 
         self.assertIn("error", result)
@@ -72,14 +73,13 @@ class TestDeleteSolutionFolder(unittest.TestCase):
         mock_response.raise_for_status = MagicMock()
 
         mock_client = _make_async_client_mock(mock_response)
-        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+        with patch("freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
             result = asyncio.run(delete_solution_folder(10))
 
         self.assertTrue(result.get("success"))
         self.assertIn("message", result)
 
     def test_delete_propagates_http_error(self):
-        import httpx
 
         mock_response = MagicMock()
         mock_response.status_code = 403
@@ -90,7 +90,7 @@ class TestDeleteSolutionFolder(unittest.TestCase):
         )
 
         mock_client = _make_async_client_mock(mock_response)
-        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+        with patch("freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
             result = asyncio.run(delete_solution_folder(999))
 
         self.assertIn("error", result)
@@ -107,14 +107,13 @@ class TestDeleteSolutionCategory(unittest.TestCase):
         mock_response.raise_for_status = MagicMock()
 
         mock_client = _make_async_client_mock(mock_response)
-        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+        with patch("freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
             result = asyncio.run(delete_solution_category(5))
 
         self.assertTrue(result.get("success"))
         self.assertIn("message", result)
 
     def test_delete_propagates_http_error(self):
-        import httpx
 
         mock_response = MagicMock()
         mock_response.status_code = 500
@@ -125,7 +124,7 @@ class TestDeleteSolutionCategory(unittest.TestCase):
         )
 
         mock_client = _make_async_client_mock(mock_response)
-        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+        with patch("freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
             result = asyncio.run(delete_solution_category(999))
 
         self.assertIn("error", result)
@@ -149,7 +148,7 @@ class TestSearchSolutionArticles(unittest.TestCase):
         mock_response.json = MagicMock(return_value=sample_articles)
 
         mock_client = _make_async_client_mock(mock_response)
-        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+        with patch("freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
             result = asyncio.run(search_solution_articles(term="reset password", page=1, per_page=10))
 
         self.assertIn("articles", result)
@@ -173,7 +172,7 @@ class TestSearchSolutionArticles(unittest.TestCase):
         mock_response.json = MagicMock(return_value=[])
 
         mock_client = _make_async_client_mock(mock_response)
-        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+        with patch("freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
             result = asyncio.run(search_solution_articles(term="test", page=2, per_page=30))
 
         self.assertEqual(result["pagination"]["current_page"], 2)
@@ -189,7 +188,6 @@ class TestSearchSolutionArticles(unittest.TestCase):
         self.assertIn("error", result)
 
     def test_search_propagates_http_error(self):
-        import httpx
 
         mock_response = MagicMock()
         mock_response.status_code = 401
@@ -201,7 +199,7 @@ class TestSearchSolutionArticles(unittest.TestCase):
         mock_response.headers = {}
 
         mock_client = _make_async_client_mock(mock_response)
-        with patch("src.freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
+        with patch("freshdesk_mcp.server.httpx.AsyncClient", return_value=mock_client):
             result = asyncio.run(search_solution_articles(term="test"))
 
         self.assertIn("error", result)


### PR DESCRIPTION
Several entities were missing create/update/delete coverage, leaving the MCP server without full CRUD capability. Contacts and companies had no write operations beyond update; agents, groups, canned responses, and field types all lacked delete. The Solutions (knowledge base) API coverage was missing delete operations for all three resource levels and article search, leaving full CRUD incomplete.

## Added tools

**Contacts**
- `create_contact()` — requires at least one of `email`, `phone`, `mobile`, `twitter_id`
- `delete_contact()`

**Companies**
- `create_company()` — requires `name`
- `update_company()`
- `delete_company()`

**Agents / Groups**
- `delete_agent()`
- `delete_group()`

**Canned Responses & Folders**
- `delete_canned_response()`
- `delete_canned_response_folder()`

**Fields**
- `delete_contact_field()`
- `delete_ticket_field()`

**Solutions**

- `delete_solution_article(article_id)` 
- `delete_solution_folder(folder_id)` 
- `delete_solution_category(category_id)` 
- `search_solution_articles(term, page, per_page)`

Search returns the standard `{"articles": [...], "pagination": {...}}` envelope.

All delete tools handle `204 No Content` explicitly and return structured error dicts on failure, consistent with the existing delete implementations (e.g. `delete_solution_article`).