### PR TITLE
feat: support cc, bcc, from_email and user_id on ticket replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ The server offers several tools for Freshdesk operations:
   - **Inputs**:
     - `ticket_id` (number, required): ID of the ticket
     - `body` (string, required): Content of the reply
+    - `cc_emails` (array of strings, optional): Additional email addresses added to the 'cc' field of the outgoing email. These supplement the ticket requester, who always remains the primary recipient
+    - `bcc_emails` (array of strings, optional): Additional email addresses added to the 'bcc' field of the outgoing email. These supplement the ticket requester, who always remains the primary recipient
+    - `from_email` (string, optional): Email address the reply is sent from
+    - `user_id` (number, optional): ID of the agent who is adding the reply
 
 - `create_ticket_note`: Add a note to a ticket
   - **Inputs**:

--- a/src/freshdesk_mcp/server.py
+++ b/src/freshdesk_mcp/server.py
@@ -404,8 +404,26 @@ async def get_ticket_conversation(ticket_id: int)-> list[Dict[str, Any]]:
         return response.json()
 
 @mcp.tool()
-async def create_ticket_reply(ticket_id: int,body: str)-> Dict[str, Any]:
-    """Create a reply to a ticket in Freshdesk."""
+async def create_ticket_reply(
+    ticket_id: int,
+    body: str,
+    cc_emails: Optional[List[str]] = None,
+    bcc_emails: Optional[List[str]] = None,
+    from_email: Optional[str] = None,
+    user_id: Optional[int] = None
+) -> Dict[str, Any]:
+    """Create a reply to a ticket in Freshdesk.
+
+    Args:
+        ticket_id: ID of the ticket to reply to
+        body: Content of the reply in HTML format
+        cc_emails: Additional email addresses added to the 'cc' field of the outgoing email.
+            These supplement the ticket requester, who always remains the primary recipient
+        bcc_emails: Additional email addresses added to the 'bcc' field of the outgoing email.
+            These supplement the ticket requester, who always remains the primary recipient
+        from_email: Email address the reply is sent from. Defaults to the global support email
+        user_id: ID of the agent who is adding the reply
+    """
     url = f"https://{FRESHDESK_DOMAIN}/api/v2/tickets/{ticket_id}/reply"
     headers = {
         "Authorization": f"Basic {base64.b64encode(f'{FRESHDESK_API_KEY}:X'.encode()).decode()}"
@@ -413,6 +431,14 @@ async def create_ticket_reply(ticket_id: int,body: str)-> Dict[str, Any]:
     data = {
         "body": body
     }
+    if cc_emails:
+        data["cc_emails"] = cc_emails
+    if bcc_emails:
+        data["bcc_emails"] = bcc_emails
+    if from_email:
+        data["from_email"] = from_email
+    if user_id:
+        data["user_id"] = user_id
     async with httpx.AsyncClient() as client:
         response = await client.post(url, headers=headers, json=data)
         return response.json()


### PR DESCRIPTION
## What

`create_ticket_reply` currently sends only `body` to the Freshdesk reply endpoint. This adds the four remaining JSON fields the endpoint accepts: `cc_emails`, `bcc_emails`, `from_email` and `user_id`.

## Why

There is no way today to copy anyone on an outgoing reply. That rules out common support flows: looping in a colleague, replying to a customer who asks that their manager be kept in the loop, or sending from a specific support address instead of the global one.

The API has supported these since v2, so this is purely a gap on the MCP side. See https://developers.freshdesk.com/api/#reply_ticket

## Backwards compatibility

All four parameters are optional and are only added to the payload when set. A call with just `ticket_id` and `body` produces a byte-identical request to the one on main.

## Notes

- The docstring documents that `cc_emails` and `bcc_emails` supplement the ticket requester rather than replace them. That text becomes the tool description an MCP client shows to the model, so the distinction matters in practice.
- `attachments` and `structured_body` are deliberately left out. Both need a different request shape (multipart, and webchat/mobile SDK tickets respectively) and belong in their own PR.
- README updated to match.
